### PR TITLE
Dirty Linux BepInEx install fix

### DIFF
--- a/modules/github.py
+++ b/modules/github.py
@@ -13,10 +13,13 @@ class GitHubUtils:
             print(f"{self.baseUrl} could not be accessed.")
 
     def initDownloadURLs(self):
+        def validate_name(name: str) -> bool:
+            return "x64" in name and "linux" not in name and "macos" not in name
+
         request = urllib.request.Request(f"https://api.github.com/repos/bepinex/bepinex/releases")
         response = json.loads(urllib.request.urlopen(request).read())
         for release in response:
-            self.downloadURLs.append(next((item["browser_download_url"] for item in release["assets"] if "x64" in item["name"]), release["assets"][0]["browser_download_url"]))
+            self.downloadURLs.append(next((item["browser_download_url"] for item in release["assets"] if validate_name(item["name"])), release["assets"][0]["browser_download_url"]))
             self.downloadVersions.append(release["tag_name"])
 
 


### PR DESCRIPTION
Starting from BepInEx v5.4.23.1, the BepInEx assets on GitHub are split into Linux, macOS and Windows, all 32-bits and 64-bits. But due to the installer checking solely for the presence of `x64` in the name and the BepInEx assets listing the Linux versions first, the installer installs a Linux version of BepInEx, thus not working on Windows.

This PR fixes this issue by checking the asset name for the absence of `linux` and `macos` in the asset name.
